### PR TITLE
PKG-2849: initial build for defaults

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - python
     - flit-core >=3.2,<4
     - pip
-    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,18 @@ source:
   sha256: dc70da89634944a579bfeec70a7a4523c53ffdb3cf52d1bb4a431fda278ddb96
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<310]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.10
+    - python
     - flit-core >=3.2,<4
     - pip
+    - wheel
   run:
-    - python >=3.10
+    - python
 
 test:
   imports:
@@ -33,10 +34,15 @@ test:
 about:
   home: https://github.com/sethmlarson/truststore
   summary: Verify certificates using native system trust stores
+  description: |
+    A library which exposes native system certificate stores (ie “trust stores”)
+    through an ssl.SSLContext-like API. This means that Python applications no
+    longer need to rely on certifi as a root certificate store.
   dev_url: https://github.com/sethmlarson/truststore
-  doc_url: https://truststore.readthedocs.io/en/latest/
+  doc_url: https://truststore.readthedocs.io/
   license: MIT
   license_file: LICENSE
+  license_family: MIT
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,23 +27,23 @@ requirements:
 test:
   requires:
     - pip
-    - aiohttp
-    - pyopenssl
-    - pytest
-    - pytest-asyncio
-    - pytest-httpserver
-    - urllib3
-    - trustme
-    - requests
-    - flaky
-    - httpx
+    - aiohttp            # [not (linux and s390x)]
+    - pyopenssl          # [not (linux and s390x)]
+    - pytest             # [not (linux and s390x)]
+    - pytest-asyncio     # [not (linux and s390x)]
+    - pytest-httpserver  # [not (linux and s390x)]
+    - urllib3            # [not (linux and s390x)]
+    - trustme            # [not (linux and s390x)]
+    - requests           # [not (linux and s390x)]
+    - flaky              # [not (linux and s390x)]
+    - httpx              # [not (linux and s390x)]
   imports:
     - truststore
   source_files:
-    - tests
+    - tests              # [not (linux and s390x)]
   commands:
     - pip check
-    - pytest -v -s -rs --no-flaky-report --max-runs=3 tests/
+    - pytest -v -s -rs --no-flaky-report --max-runs=3 tests/  # [not (linux and s390x)]
 
 about:
   home: https://github.com/sethmlarson/truststore

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,9 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/truststore-{{ version }}.tar.gz
-  sha256: dc70da89634944a579bfeec70a7a4523c53ffdb3cf52d1bb4a431fda278ddb96
+  url: https://github.com/sethmlarson/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
+  sha256: c862292f8d136bfcf2a7827a1fd1c1b27944a982741205fb466005673b570df8
 
 build:
   skip: True  # [py<310]
@@ -24,12 +25,25 @@ requirements:
     - python
 
 test:
-  imports:
-    - truststore
-  commands:
-    - pip check
   requires:
     - pip
+    - aiohttp
+    - pyopenssl
+    - pytest
+    - pytest-asyncio
+    - pytest-httpserver
+    - urllib3
+    - trustme
+    - requests
+    - flaky
+    - httpx
+  imports:
+    - truststore
+  source_files:
+    - tests
+  commands:
+    - pip check
+    - pytest -v -s -rs --no-flaky-report --max-runs=3 tests/
 
 about:
   home: https://github.com/sethmlarson/truststore


### PR DESCRIPTION
This is a requirement for a new conda feature.

A few comments:
- this library may use the certificate store from the system, "leaking" our environment "sandbox". some issue may arise if the users' systems somehow have the certs installed in non-default paths, but I believe that this is expected behavior.
- despite the library mentioning openssl, the actual openssl library or pyopenssl are not required by the library, as it relies on the `ssl` module, that encapsulates whatever ssl implementation python was built against.

cc @jezdez 